### PR TITLE
Replace DSMR library usage with manual telegram parser

### DIFF
--- a/P1reader_esp32.ino
+++ b/P1reader_esp32.ino
@@ -1,27 +1,204 @@
 #include <Arduino.h>
-#include <dsmr.h>
 
 // Change these pin numbers to match your wiring.
 constexpr int P1_RX_PIN = 44;   // UART input from the smart meter
 constexpr int P1_TX_PIN = 43;   // Not used by the meter but required by HardwareSerial
 constexpr int P1_RTS_PIN = 48;  // Optional: controls the smart meter's data request pin
 
-// The library lets you declare which values from the telegram you want to decode.
-using P1Data = dsmr::ParsedData<
-  dsmr::Identification,
-  dsmr::P1Version,
-  dsmr::Timestamp,
-  dsmr::ElectricityDeliveredTariff1,
-  dsmr::ElectricityDeliveredTariff2,
-  dsmr::ElectricityReturnedTariff1,
-  dsmr::ElectricityReturnedTariff2,
-  dsmr::PowerDelivered,
-  dsmr::PowerReturned,
-  dsmr::GasDelivered
->;
+struct P1Data {
+  bool identificationPresent = false;
+  String identification;
+
+  bool p1VersionPresent = false;
+  String p1Version;
+
+  bool timestampPresent = false;
+  String timestamp;
+
+  bool electricityDeliveredTariff1Present = false;
+  float electricityDeliveredTariff1 = 0.0f;
+
+  bool electricityDeliveredTariff2Present = false;
+  float electricityDeliveredTariff2 = 0.0f;
+
+  bool electricityReturnedTariff1Present = false;
+  float electricityReturnedTariff1 = 0.0f;
+
+  bool electricityReturnedTariff2Present = false;
+  float electricityReturnedTariff2 = 0.0f;
+
+  bool powerDeliveredPresent = false;
+  float powerDelivered = 0.0f;
+
+  bool powerReturnedPresent = false;
+  float powerReturned = 0.0f;
+
+  bool gasDeliveredPresent = false;
+  float gasDelivered = 0.0f;
+};
 
 HardwareSerial P1Serial(1);
-P1Data data;
+
+namespace {
+
+String telegramBuffer;
+bool telegramStarted = false;
+bool telegramTerminatorSeen = false;
+
+bool readTelegram(Stream &serial, String &telegram) {
+  while (serial.available()) {
+    char c = static_cast<char>(serial.read());
+
+    if (!telegramStarted) {
+      if (c != '/') {
+        continue;  // Wait for the telegram header.
+      }
+      telegramStarted = true;
+      telegramBuffer = "";
+      telegramTerminatorSeen = false;
+    }
+
+    telegramBuffer += c;
+
+    if (c == '!') {
+      telegramTerminatorSeen = true;
+    } else if (telegramTerminatorSeen && c == '\n') {
+      telegram = telegramBuffer;
+      telegramBuffer = "";
+      telegramStarted = false;
+      telegramTerminatorSeen = false;
+      return true;
+    }
+
+    if (telegramBuffer.length() > 1024) {
+      telegramBuffer = "";
+      telegramStarted = false;
+      telegramTerminatorSeen = false;
+    }
+  }
+
+  return false;
+}
+
+bool lineForObis(const String &telegram, const String &obis, String &line) {
+  int start = telegram.indexOf(obis);
+  if (start < 0) {
+    return false;
+  }
+
+  int end = telegram.indexOf('\n', start);
+  if (end < 0) {
+    end = telegram.length();
+  }
+
+  line = telegram.substring(start, end);
+  return true;
+}
+
+bool extractParenthesizedValue(const String &line, size_t pairIndex, String &value) {
+  size_t currentPair = 0;
+  int start = -1;
+
+  for (size_t i = 0; i < line.length(); ++i) {
+    char c = line.charAt(i);
+    if (c == '(') {
+      start = static_cast<int>(i) + 1;
+    } else if (c == ')' && start >= 0) {
+      if (currentPair == pairIndex) {
+        value = line.substring(start, static_cast<int>(i));
+        return true;
+      }
+      ++currentPair;
+      start = -1;
+    }
+  }
+
+  return false;
+}
+
+float parseNumber(const String &token) {
+  String number = token;
+  int unitPos = number.indexOf('*');
+  if (unitPos >= 0) {
+    number = number.substring(0, unitPos);
+  }
+
+  number.trim();
+  return number.toFloat();
+}
+
+bool parseTelegram(const String &telegram, P1Data &data) {
+  auto assignString = [](String &target, bool &flag, const String &value) {
+    target = value;
+    target.trim();
+    flag = true;
+  };
+
+  auto assignFloat = [](float &target, bool &flag, const String &value) {
+    target = parseNumber(value);
+    flag = true;
+  };
+
+  String line;
+  String value;
+
+  if (lineForObis(telegram, "0-0:96.1.1", line) &&
+      extractParenthesizedValue(line, 0, value)) {
+    assignString(data.identification, data.identificationPresent, value);
+  }
+
+  if (lineForObis(telegram, "1-3:0.2.8", line) &&
+      extractParenthesizedValue(line, 0, value)) {
+    assignString(data.p1Version, data.p1VersionPresent, value);
+  }
+
+  if (lineForObis(telegram, "0-0:1.0.0", line) &&
+      extractParenthesizedValue(line, 0, value)) {
+    assignString(data.timestamp, data.timestampPresent, value);
+  }
+
+  if (lineForObis(telegram, "1-0:1.8.1", line) &&
+      extractParenthesizedValue(line, 0, value)) {
+    assignFloat(data.electricityDeliveredTariff1, data.electricityDeliveredTariff1Present, value);
+  }
+
+  if (lineForObis(telegram, "1-0:1.8.2", line) &&
+      extractParenthesizedValue(line, 0, value)) {
+    assignFloat(data.electricityDeliveredTariff2, data.electricityDeliveredTariff2Present, value);
+  }
+
+  if (lineForObis(telegram, "1-0:2.8.1", line) &&
+      extractParenthesizedValue(line, 0, value)) {
+    assignFloat(data.electricityReturnedTariff1, data.electricityReturnedTariff1Present, value);
+  }
+
+  if (lineForObis(telegram, "1-0:2.8.2", line) &&
+      extractParenthesizedValue(line, 0, value)) {
+    assignFloat(data.electricityReturnedTariff2, data.electricityReturnedTariff2Present, value);
+  }
+
+  if (lineForObis(telegram, "1-0:1.7.0", line) &&
+      extractParenthesizedValue(line, 0, value)) {
+    assignFloat(data.powerDelivered, data.powerDeliveredPresent, value);
+  }
+
+  if (lineForObis(telegram, "1-0:2.7.0", line) &&
+      extractParenthesizedValue(line, 0, value)) {
+    assignFloat(data.powerReturned, data.powerReturnedPresent, value);
+  }
+
+  if (lineForObis(telegram, "0-1:24.2.1", line) &&
+      extractParenthesizedValue(line, 1, value)) {
+    assignFloat(data.gasDelivered, data.gasDeliveredPresent, value);
+  }
+
+  return data.identificationPresent || data.p1VersionPresent || data.timestampPresent ||
+         data.electricityDeliveredTariff1Present || data.electricityDeliveredTariff2Present ||
+         data.electricityReturnedTariff1Present || data.electricityReturnedTariff2Present ||
+         data.powerDeliveredPresent || data.powerReturnedPresent || data.gasDeliveredPresent;
+}
+
+}  // namespace
 
 void setup() {
   Serial.begin(115200);
@@ -39,48 +216,67 @@ void setup() {
 }
 
 void loop() {
-  if (dsmr::telegram::read(P1Serial, data)) {
-    Serial.println(F("--- New telegram ---"));
+  String telegram;
+  if (!readTelegram(P1Serial, telegram)) {
+    return;
+  }
 
-    if (data.timestamp_present) {
-      Serial.print(F("Timestamp: "));
-      Serial.println(data.timestamp);
-    }
+  P1Data data;
+  if (!parseTelegram(telegram, data)) {
+    Serial.println(F("Kon telegram niet parseren."));
+    return;
+  }
 
-    if (data.electricity_delivered_tariff1_present) {
-      Serial.print(F("Delivered T1: "));
-      Serial.println(data.electricity_delivered_tariff1);
-    }
+  Serial.println(F("--- New telegram ---"));
 
-    if (data.electricity_delivered_tariff2_present) {
-      Serial.print(F("Delivered T2: "));
-      Serial.println(data.electricity_delivered_tariff2);
-    }
+  if (data.identificationPresent) {
+    Serial.print(F("Meter ID: "));
+    Serial.println(data.identification);
+  }
 
-    if (data.electricity_returned_tariff1_present) {
-      Serial.print(F("Returned T1: "));
-      Serial.println(data.electricity_returned_tariff1);
-    }
+  if (data.p1VersionPresent) {
+    Serial.print(F("P1 versie: "));
+    Serial.println(data.p1Version);
+  }
 
-    if (data.electricity_returned_tariff2_present) {
-      Serial.print(F("Returned T2: "));
-      Serial.println(data.electricity_returned_tariff2);
-    }
+  if (data.timestampPresent) {
+    Serial.print(F("Timestamp: "));
+    Serial.println(data.timestamp);
+  }
 
-    if (data.power_delivered_present) {
-      Serial.print(F("Power delivered: "));
-      Serial.println(data.power_delivered);
-    }
+  if (data.electricityDeliveredTariff1Present) {
+    Serial.print(F("Delivered T1 (kWh): "));
+    Serial.println(data.electricityDeliveredTariff1, 3);
+  }
 
-    if (data.power_returned_present) {
-      Serial.print(F("Power returned: "));
-      Serial.println(data.power_returned);
-    }
+  if (data.electricityDeliveredTariff2Present) {
+    Serial.print(F("Delivered T2 (kWh): "));
+    Serial.println(data.electricityDeliveredTariff2, 3);
+  }
 
-    if (data.gas_delivered_present) {
-      Serial.print(F("Gas delivered: "));
-      Serial.println(data.gas_delivered);
-    }
+  if (data.electricityReturnedTariff1Present) {
+    Serial.print(F("Returned T1 (kWh): "));
+    Serial.println(data.electricityReturnedTariff1, 3);
+  }
+
+  if (data.electricityReturnedTariff2Present) {
+    Serial.print(F("Returned T2 (kWh): "));
+    Serial.println(data.electricityReturnedTariff2, 3);
+  }
+
+  if (data.powerDeliveredPresent) {
+    Serial.print(F("Power delivered (kW): "));
+    Serial.println(data.powerDelivered, 3);
+  }
+
+  if (data.powerReturnedPresent) {
+    Serial.print(F("Power returned (kW): "));
+    Serial.println(data.powerReturned, 3);
+  }
+
+  if (data.gasDeliveredPresent) {
+    Serial.print(F("Gas delivered (m3): "));
+    Serial.println(data.gasDelivered, 3);
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # ESP32-S3 DSMR P1 reader
 
-Eenvoudig Arduino voorbeeld dat een DSMR 5 slimme meter uitleest via de P1-poort
-met behulp van de [matthijskooijman/arduino-dsmr](https://github.com/matthijskooijman/arduino-dsmr)
-library.
+Eenvoudig Arduino voorbeeld dat een DSMR 5 slimme meter uitleest via de P1-poort.
+De sketch verzamelt een compleet telegram, zoekt daarin naar de relevante OBIS-codes
+en toont de gevonden waarden op de seriële monitor. Er is geen externe DSMR-library
+meer nodig: alle parsing gebeurt in de sketch zelf.
 
 ## Bestanden
 
@@ -10,9 +11,8 @@ library.
 
 ## Gebruik
 
-1. Installeer de **arduino-dsmr** library in de Arduino IDE of via PlatformIO.
-2. Open de `P1reader_esp32.ino` sketch.
-3. Pas indien nodig de pinnen `P1_RX_PIN`, `P1_TX_PIN` en `P1_RTS_PIN` aan je eigen
+1. Open de `P1reader_esp32.ino` sketch in de Arduino IDE of PlatformIO.
+2. Pas indien nodig de pinnen `P1_RX_PIN`, `P1_TX_PIN` en `P1_RTS_PIN` aan je eigen
    hardware aan.
-4. Upload naar de ESP32-S3.
-5. Monitor de seriële poort op 115200 baud om de telegram-waarden te zien.
+3. Upload naar de ESP32-S3.
+4. Monitor de seriële poort op 115200 baud om de telegram-waarden te zien.


### PR DESCRIPTION
## Summary
- add a lightweight parser that reads DSMR telegrams from the P1 port and extracts the desired OBIS values without the arduino-dsmr library
- adjust the loop logic to print the parsed readings with basic unit formatting and a fallback error message when parsing fails
- update the README to document the new built-in parser and simplified setup steps

## Testing
- not run (not feasible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5322e424483228b96dcfffd78eb1a